### PR TITLE
EVG-2512 upgrade react-highlight-words to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-bootstrap": "^0.31.5",
     "react-dom": "^15.6.2",
     "react-form": "^1.3.0",
-    "react-highlight-words": "^0.10.0",
+    "react-highlight-words": "^0.11.0",
     "react-list": "^0.8.8",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",

--- a/src/components/Fetch/index.js
+++ b/src/components/Fetch/index.js
@@ -250,8 +250,6 @@ componentWillReceiveProps(nextProps){
     if(event) {
       event.preventDefault();
     }
-    // Trim |'s so highlighter doesn't hang.
-    this.findInput.value=this.findInput.value.replace(/(^\|)|(\|$)/g, "");
     let findRegexp = this.findInput.value;
 
     if(findRegexp == "") {


### PR DESCRIPTION
A bugfix in the latest version will allow us to perform proper
highlighting for search strings ending in an escaped pipe "|" character.