### PR TITLE
EVG-6312 Make text of expandable lobster lines unselectable

### DIFF
--- a/src/components/LogView/ExpandableLogLine.js
+++ b/src/components/LogView/ExpandableLogLine.js
@@ -26,14 +26,23 @@ export default class ExpandableLogLine extends React.PureComponent<Props> {
     const skipped = this.props.end - this.props.start + 1
     return (
       <div
+        className="expandable-container"
+      >
+      <span
         className="expandable"
       >
-        ⬍ ~ ~ ~ {skipped} line{skipped > 1 ? 's' : ''} skipped.
+        ⬍ ~ ~ ~ 
+      </span>
+      <span className="expandable expandable-selectable">
+      {skipped} line{skipped > 1 ? 's' : ''} skipped. 
+      </span>
+      <span className="expandable">
         Expand:&nbsp;
         <a onClick={this.expandRange(skipped)}>All</a>
         ,&nbsp;
         <a onClick={this.expandRange(5)}>Five</a>&nbsp;
       ~ ~ ~
+      </span>
       </div>
     )
   }

--- a/src/components/LogView/ExpandableLogLine.js
+++ b/src/components/LogView/ExpandableLogLine.js
@@ -31,10 +31,10 @@ export default class ExpandableLogLine extends React.PureComponent<Props> {
       <span
         className="expandable"
       >
-        ⬍ ~ ~ ~ 
+        ⬍ ~ ~ ~
       </span>
       <span className="expandable-selectable">
-      {skipped} line{skipped > 1 ? 's' : ''} skipped. 
+      {skipped} line{skipped > 1 ? 's' : ''} skipped.
       </span>
       <span className="expandable">
         Expand:&nbsp;

--- a/src/components/LogView/ExpandableLogLine.js
+++ b/src/components/LogView/ExpandableLogLine.js
@@ -33,7 +33,7 @@ export default class ExpandableLogLine extends React.PureComponent<Props> {
       >
         ⬍ ~ ~ ~ 
       </span>
-      <span className="expandable expandable-selectable">
+      <span className="expandable-selectable">
       {skipped} line{skipped > 1 ? 's' : ''} skipped. 
       </span>
       <span className="expandable">

--- a/src/components/LogView/style.css
+++ b/src/components/LogView/style.css
@@ -15,12 +15,6 @@
   user-select: none;
 }
 .expandable-selectable {
-  -webkit-user-select: text;
-  -khtml-user-select: text;
-  -moz-user-select: text;
-  -ms-user-select: text;
-  -o-user-select: text;
-  user-select: text;
   margin-inline: 1em;
 }
 .monospace { font-family: monospace;}

--- a/src/components/LogView/style.css
+++ b/src/components/LogView/style.css
@@ -2,15 +2,26 @@
 .highlighted { background-color: #fff0f2; }
 .filtered { background-color: #ffdde3; }
 .no-match { background-color: #e8e7d9; }
-.expandable {
+.expandable-container {
   background-color: #dde4f3;
   box-shadow: inset 0 0 5px #8f8fcd;
+}
+.expandable {
   -webkit-user-select: none;
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   -o-user-select: none;
   user-select: none;
+}
+.expandable-selectable {
+  -webkit-user-select: text;
+  -khtml-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  -o-user-select: text;
+  user-select: text;
+  margin-inline: 1em;
 }
 .monospace { font-family: monospace;}
 .hover-highlight:hover {

--- a/src/components/LogView/style.css
+++ b/src/components/LogView/style.css
@@ -5,6 +5,12 @@
 .expandable {
   background-color: #dde4f3;
   box-shadow: inset 0 0 5px #8f8fcd;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 .monospace { font-family: monospace;}
 .hover-highlight:hover {


### PR DESCRIPTION
This lets you copy blocks of lines that include expandable rows without also copying over the text of the expandable rows. 

Example:

line 1
line 2
~ ~ 10 lines skipped. Expand: All, Five ~ ~ ~
line 3
line 4

becomes

line 1
line 2
line 3
line 4

Equivalent to hiding expandable rows before selecting your text. 