### PR TITLE
Update regex to recognize shortened resmoke prefixes and colorize them appropriately

### DIFF
--- a/src/reducers/logProcessor/resmoke.js
+++ b/src/reducers/logProcessor/resmoke.js
@@ -28,7 +28,7 @@ export default function(state: Log, response: string): Log {
   const gitPrefixLen = gitPrefix.length + 2;
   let gitVersionStr: string = 'master';
   const portRegex = / [sdbc](\d{1,5})\|/;
-  const stateRegex = /(:shard\d*|:configsvr)?:(initsync|primary|mongos|secondary\d*|node\d*)]/;
+  const stateRegex = /(:s(hard)?\d*|:c(onfigsvr)?)?:(initsync|prim(ary)?|(mongo)?s|sec(ondary)?\d*|n(ode)?\d*)]/;
 
   const colorMap = {};
 


### PR DESCRIPTION
Supporting change for https://jira.mongodb.org/browse/SERVER-54723

Change was tested locally:

1. Shortened prefixes

before:
![shortened-prefixes-now](https://user-images.githubusercontent.com/15146221/109330035-50a93680-786c-11eb-9554-7812db26a520.jpg)

after:
![shortened-prefixes-updated-regex](https://user-images.githubusercontent.com/15146221/109329957-3bcca300-786c-11eb-97fa-61accc9977b4.jpg)

2. Old prefixes

before:
![old-prefixes-now](https://user-images.githubusercontent.com/15146221/109330147-6c144180-786c-11eb-8128-a79e42c5df2f.jpg)

after:
![old-prefixes-updated-regex](https://user-images.githubusercontent.com/15146221/109330172-71718c00-786c-11eb-8b26-624a56d1b19e.jpg)
