### PR TITLE
EVG-6089: Jump to first user-bookmarked log line (if any)  & turn off line wrap option on page load

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "lint:fix": "eslint --ext .js,.jsx --fix .",
     "eslint": "eslint --ext .js,.jsx",
     "debug": "react-scripts --inspect-brk test --runInBand --env=jsdom",
-    "generate-tasks": "node generate-tasks.js"
+    "generate-tasks": "node generate-tasks.js",
+    "prettier": "./node_modules/.bin/prettier --write ./src"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.6",

--- a/src/components/Fetch/index.js
+++ b/src/components/Fetch/index.js
@@ -1,7 +1,6 @@
 // @flow strict
 
 import React from "react";
-import type { Node as ReactNode } from "react";
 import * as actions from "../../actions";
 import "./style.css";
 import LogView from "../LogView/index";
@@ -27,12 +26,6 @@ export class Fetch extends React.PureComponent<Props> {
     }
   }
 
-  showLines(): ?ReactNode {
-    if (!this.props.lines) {
-      return <div />;
-    }
-    return <LogView />;
-  }
 
   render() {
     return (
@@ -40,7 +33,9 @@ export class Fetch extends React.PureComponent<Props> {
         <Bookmarks />
         <div className="main">
           <Toolbar />
-          <div className="log-list">{this.showLines()}</div>
+          <div className="log-list">
+            <LogView />
+          </div>
         </div>
       </div>
     );

--- a/src/components/Fetch/index.js
+++ b/src/components/Fetch/index.js
@@ -26,7 +26,6 @@ export class Fetch extends React.PureComponent<Props> {
     }
   }
 
-
   render() {
     return (
       <div>

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -53,6 +53,7 @@ function newSkipLine(start, end): SkipLine {
 }
 
 type State = {
+  hasScrolledToFirstBookmark: boolean,
   selectStartIndex: ?number,
   selectEndIndex: ?number,
   lines: Array<Line | SkipLine>,
@@ -67,6 +68,7 @@ class LogView extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
+      hasScrolledToFirstBookmark: props.bookmarks.length === 0,
       selectStartIndex: null,
       selectEndIndex: null,
       clicks: [],
@@ -367,6 +369,36 @@ class LogView extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
+    const currBookmarksSet = new Set(this.props.bookmarks.map(({lineNumber}) => lineNumber));
+    const lastLineNo = this.state.lines.length - 1;
+    if (
+      // Don't scroll unless lines are rendered and bookmarks exist
+      this.state.lines.length > 0 &&
+      prevState.lines.length === 0 &&
+      this.props.bookmarks.length &&
+      // Don't scroll when the bookmarks look like [0, last line]
+      !(
+        currBookmarksSet.size === 2 &&
+        currBookmarksSet.has(0) &&
+        currBookmarksSet.has(lastLineNo)
+      ) &&
+      // Don't scroll when we already tried to scroll before lol
+      !this.state.hasScrolledToFirstBookmark
+    ) {
+      const sortedBookmarks = [...this.props.bookmarks].sort(
+        (a, b) => a.lineNumber - b.lineNumber
+      );
+      for (let i = 0; i < sortedBookmarks.length; i++) {
+        const { lineNumber } = sortedBookmarks[i];
+        // don't bother scrolling to first line bc it's visible on render
+        if (lineNumber !== 0) {
+          this.setState({ hasScrolledToFirstBookmark: true }, () => {
+            this.props.scrollToLine(lineNumber);
+          });
+          break;
+        }
+      }
+    }
     if (
       this.props.scrollLine !== null &&
       this.props.scrollLine >= 0 &&

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -400,9 +400,11 @@ class LogView extends React.Component<Props, State> {
       );
       const { lineNumber } =
         sortedBookmarks.find(({ lineNumber }) => lineNumber !== 0) || {};
-      this.setState({ hasScrolledToFirstBookmark: true }, () => {
-        this.props.scrollToLine(lineNumber);
-      });
+      if (lineNumber !== undefined) {
+        this.setState({ hasScrolledToFirstBookmark: true }, () => {
+          this.props.scrollToLine(lineNumber);
+        });
+      }
     }
 
     if (

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -385,7 +385,7 @@ class LogView extends React.Component<Props, State> {
       // Don't scroll unless lines are rendered and bookmarks exist
       this.state.lines.length > 0 &&
       prevState.lines.length === 0 &&
-      this.props.bookmarks.length &&
+      this.props.bookmarks.length > 0 &&
       // Don't scroll when the bookmarks look like [0, last line]
       !(
         currBookmarksSet.size === 2 &&
@@ -398,16 +398,11 @@ class LogView extends React.Component<Props, State> {
       const sortedBookmarks = [...this.props.bookmarks].sort(
         (a, b) => a.lineNumber - b.lineNumber
       );
-      for (let i = 0; i < sortedBookmarks.length; i++) {
-        const { lineNumber } = sortedBookmarks[i];
-        // don't bother scrolling to first line bc it's visible on render
-        if (lineNumber !== 0) {
-          this.setState({ hasScrolledToFirstBookmark: true }, () => {
-            this.props.scrollToLine(lineNumber);
-          });
-          break;
-        }
-      }
+      const { lineNumber } =
+        sortedBookmarks.find(({ lineNumber }) => lineNumber !== 0) || {};
+      this.setState({ hasScrolledToFirstBookmark: true }, () => {
+        this.props.scrollToLine(lineNumber);
+      });
     }
 
     if (

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -6,7 +6,7 @@ import FullLogLine from "./FullLogLine";
 import ExpandableLogLine from "./ExpandableLogLine";
 import { findJSONObjectsInLine } from "./LogLineText";
 import { connect } from "react-redux";
-import { scrollToLine, toggleBookmark } from "../../actions";
+import { scrollToLine, toggleBookmark, toggleLineWrap } from "../../actions";
 import * as selectors from "../../selectors";
 import type {
   ReduxState,
@@ -39,6 +39,7 @@ type Props = {
   toggleBookmark: (number[]) => void,
   scrollToLine: (number) => void,
   prettyPrint: boolean,
+  toggleWrap: () => void,
 };
 
 type SkipLine = {|
@@ -368,9 +369,18 @@ class LogView extends React.Component<Props, State> {
     }
   }
 
+  componentDidMount() {
+    if (this.props.wrap) {
+      this.props.toggleWrap();
+    }
+  }
+
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const currBookmarksSet = new Set(this.props.bookmarks.map(({lineNumber}) => lineNumber));
+    const currBookmarksSet = new Set(
+      this.props.bookmarks.map(({ lineNumber }) => lineNumber)
+    );
     const lastLineNo = this.state.lines.length - 1;
+    // handle initial bookmark scroll
     if (
       // Don't scroll unless lines are rendered and bookmarks exist
       this.state.lines.length > 0 &&
@@ -399,6 +409,7 @@ class LogView extends React.Component<Props, State> {
         }
       }
     }
+
     if (
       this.props.scrollLine !== null &&
       this.props.scrollLine >= 0 &&
@@ -475,8 +486,9 @@ function mapStateToProps(
 function mapDispatchToProps(dispatch: Dispatch<*>, ownProps: $Shape<Props>) {
   return {
     ...ownProps,
-    toggleBookmark: (bk: number[]) => dispatch(toggleBookmark(bk)),
     scrollToLine: (n: number) => dispatch(scrollToLine(n)),
+    toggleBookmark: (bk: number[]) => dispatch(toggleBookmark(bk)),
+    toggleWrap: () => dispatch(toggleLineWrap()),
   };
 }
 

--- a/src/selectors/jira.js
+++ b/src/selectors/jira.js
@@ -6,33 +6,34 @@ import type { ReduxState, Line, Bookmark } from "../models";
 const getLogLines = (state) => state.log.lines;
 const getBookmarks = (state) => state.logviewer.bookmarks;
 
-const getJiraTemplate = createSelector(getLogLines, getBookmarks, function (
-  lines: Line[],
-  bookmarks: Bookmark[]
-) {
-  if (bookmarks.length === 0 || lines.length === 0) {
-    return "";
-  }
-
-  let text = "{noformat}\n";
-  for (let i = 0; i < bookmarks.length; i++) {
-    const curr = bookmarks[i].lineNumber;
-    if (curr >= lines.length) {
-      text += "{noformat}";
-      return text;
+const getJiraTemplate = createSelector(
+  getLogLines,
+  getBookmarks,
+  function (lines: Line[], bookmarks: Bookmark[]) {
+    if (bookmarks.length === 0 || lines.length === 0) {
+      return "";
     }
 
-    text += lines[curr].text + "\n";
-    if (
-      i !== bookmarks.length - 1 &&
-      bookmarks[i + 1].lineNumber !== curr + 1
-    ) {
-      text += "...\n";
+    let text = "{noformat}\n";
+    for (let i = 0; i < bookmarks.length; i++) {
+      const curr = bookmarks[i].lineNumber;
+      if (curr >= lines.length) {
+        text += "{noformat}";
+        return text;
+      }
+
+      text += lines[curr].text + "\n";
+      if (
+        i !== bookmarks.length - 1 &&
+        bookmarks[i + 1].lineNumber !== curr + 1
+      ) {
+        text += "...\n";
+      }
     }
+    text += "{noformat}";
+    return text;
   }
-  text += "{noformat}";
-  return text;
-});
+);
 
 // because this function memoises based on its parameters, prevent the user
 // from passing the components props into it. Ideally, all users are relying on


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-6089
to test:
`gh pr checkout 93; npm install; npm run start`
then navigate to:
http://localhost:3000/lobster/evergreen/task/evergreen_ubuntu1604_test_graphql_patch_29ab59687b2dcff93f3530d1d8571c7830cb8bd8_604650a3a4cf471076131dea_21_03_08_16_28_21/0/agent#bookmarks=0%2C60%2C92&l=1

please mess with the bookmark url params, click on the bookmarks on the left side of the page to add and remove bookmarks.
the code should jump to the lowest non-zero log line unless the bookmarks are represented by {line 0, last line} in which we shouldn't jump at all
