### PR TITLE
 EVG-14188: Share line feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,6 +190,60 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
+      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "node": ">=8.6"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@fortawesome/react-fontawesome": "^0.1.14",
     "babel-polyfill": "^6.26.0",
     "body-parser": "^1.18.3",
     "decode-uri-component": "^0.2.0",

--- a/src/actions/logviewer.js
+++ b/src/actions/logviewer.js
@@ -18,6 +18,7 @@ export const LOGVIEWER_TOGGLE_SETTINGS_PANEL =
   "logviewer:toggle-settings-panel";
 export const LOGVIEWER_SEARCH_EVENT = "logviewer:search-event";
 export const LOGVIEWER_SCROLL_TO_LINE = "logviewer:scroll-to-line";
+export const LOGVIEWER_LOAD_SHARE_LINE = "logviewer:load-share-line";
 
 export type ChangeSetting = {|
   type: "logviewer:change-setting",
@@ -140,6 +141,15 @@ export type ScrollToLine = $Exact<{
   >,
 }>;
 
+export type LoadShareLine = $Exact<{
+  type: "logviewer:load-share-line",
+  +payload: $Exact<
+    $ReadOnly<{
+      lineNum: number,
+    }>
+  >,
+}>;
+
 export type Action =
   | ChangeSetting
   | ChangeFilter
@@ -154,7 +164,8 @@ export type Action =
   | LoadHighlights
   | LoadFilters
   | ToggleSettingsPanel
-  | ScrollToLine;
+  | ScrollToLine
+  | LoadShareLine;
 
 function toggleSetting(setting: string): ChangeSetting {
   return {
@@ -367,6 +378,15 @@ export function scrollToLine(n: number): ScrollToLine {
     type: LOGVIEWER_SCROLL_TO_LINE,
     payload: {
       line: n,
+    },
+  };
+}
+
+export function loadShareLine(n: number): loadScrollLine {
+  return {
+    type: LOGVIEWER_LOAD_SHARE_LINE,
+    payload: {
+      lineNum: n,
     },
   };
 }

--- a/src/components/Fetch/Bookmarks.js
+++ b/src/components/Fetch/Bookmarks.js
@@ -27,19 +27,27 @@ export class Bookmarks extends React.PureComponent<Props> {
   };
 
   render() {
+    const { shareLine, bookmarks } = this.props;
     return (
       <div className="bookmarks-bar monospace">
         <div>
-          {this.props.bookmarks.map((bookmark, key) => {
-            return (
-              <Bookmark
-                key={key}
-                lineNumber={bookmark.lineNumber}
-                scrollFunc={this.scroll}
-                emphasize={bookmark.lineNumber === this.props.shareLine}
-              />
-            );
-          })}
+          {Array.from(
+            new Set([
+              ...bookmarks.map(({ lineNumber }) => lineNumber),
+              ...(shareLine > -1 ? [shareLine] : []),
+            ])
+          )
+            .sort((a, b) => (a < b ? -1 : 1))
+            .map((bookmark, key) => {
+              return (
+                <Bookmark
+                  key={key}
+                  lineNumber={bookmark}
+                  scrollFunc={this.scroll}
+                  emphasize={bookmark === shareLine}
+                />
+              );
+            })}
         </div>
       </div>
     );

--- a/src/components/Fetch/Bookmarks.js
+++ b/src/components/Fetch/Bookmarks.js
@@ -2,6 +2,8 @@
 
 import React from "react";
 import { connect } from "react-redux";
+import { faArrowCircleLeft } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as actions from "../../actions";
 import * as selectors from "../../selectors";
 import type {
@@ -14,6 +16,7 @@ import "./style.css";
 type Props = {|
   bookmarks: BookmarkType[],
   scrollToLine: (number) => void,
+  shareLine: number,
 |};
 
 export class Bookmarks extends React.PureComponent<Props> {
@@ -33,6 +36,7 @@ export class Bookmarks extends React.PureComponent<Props> {
                 key={key}
                 lineNumber={bookmark.lineNumber}
                 scrollFunc={this.scroll}
+                emphasize={bookmark.lineNumber === this.props.shareLine}
               />
             );
           })}
@@ -45,12 +49,14 @@ export class Bookmarks extends React.PureComponent<Props> {
 export type BookmarkProps = {
   lineNumber: number,
   scrollFunc: (event: SyntheticMouseEvent<HTMLInputElement>) => void,
+  emphasize: boolean,
 };
 
 export const Bookmark = (props: BookmarkProps) => {
   return (
     <div className="bookmark" onClick={props.scrollFunc} key={props.lineNumber}>
-      {props.lineNumber}
+      {props.lineNumber}{" "}
+      {props.emphasize && <FontAwesomeIcon icon={faArrowCircleLeft} />}
     </div>
   );
 };
@@ -59,6 +65,7 @@ function mapStateToProps(state: ReduxState, ownProps: $Shape<Props>) {
   return {
     ...ownProps,
     bookmarks: selectors.getLogViewerBookmarks(state),
+    shareLine: selectors.getLogViewerShareLine(state),
   };
 }
 

--- a/src/components/Fetch/style.css
+++ b/src/components/Fetch/style.css
@@ -10,7 +10,7 @@
     font-size: 16px;
 }
 .bookmarks-bar {
-    width: 60px;
+    width: 70px;
     height: 100vh;
     background-color: #DDDDDD;
     position: fixed;
@@ -30,7 +30,7 @@
 }
 
 .main {
-    margin-left: 65px;
+    margin-left: 75px;
 }
 
 .find-box {

--- a/src/components/Fetch/style.css
+++ b/src/components/Fetch/style.css
@@ -30,7 +30,7 @@
 }
 
 .main {
-    margin-left: 75px;
+    margin-left: 70px;
 }
 
 .find-box {

--- a/src/components/LogView/FullLogLine.js
+++ b/src/components/LogView/FullLogLine.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faLink } from "@fortawesome/free-solid-svg-icons";
+import { faLink, faArrowCircleLeft } from "@fortawesome/free-solid-svg-icons";
 import LogLineText from "./LogLineText";
 import { connect } from "react-redux";
 import LineNumber from "./LineNumber";
@@ -18,7 +18,7 @@ import type {
 } from "src/models";
 
 type Props = {
-  shareLine: number,
+  isShareLine: boolean,
   bookmarked: boolean,
   caseSensitive: boolean,
   colorMap: ColorMap,
@@ -78,6 +78,9 @@ class FullLogLine extends React.Component<Props, State> {
     if (this.props.bookmarked) {
       className += " bookmark-line";
     }
+    if (this.props.isShareLine) {
+      className += " share-line";
+    }
     if (!this.props.wrap) {
       className += " no-wrap";
     } else {
@@ -94,6 +97,7 @@ class FullLogLine extends React.Component<Props, State> {
     }
     return (
       <div
+        style={{ paddingLeft: 5 }}
         className={className}
         onMouseUp={this.handleMouseUp}
         onMouseDown={this.handleMouseDown}
@@ -103,10 +107,9 @@ class FullLogLine extends React.Component<Props, State> {
             const nextHash = queryString.stringify({
               ...queryString.parseUrl(window.location.href.replace("#", "?"))
                 .query,
-              shareLine:
-                this.props.line.lineNumber === this.props.shareLine
-                  ? -1
-                  : this.props.line.lineNumber,
+              shareLine: this.props.isShareLine
+                ? -1
+                : this.props.line.lineNumber,
             });
             window.history.replaceState(
               {},
@@ -122,7 +125,12 @@ class FullLogLine extends React.Component<Props, State> {
           lineNumber={this.props.line.lineNumber}
           toggleBookmark={this.props.toggleBookmark}
           handleDoubleClick={this.props.handleDoubleClick}
-        />
+        >
+          {this.props.isShareLine && (
+            <FontAwesomeIcon icon={faArrowCircleLeft} />
+          )}
+        </LineNumber>
+
         <LogOptions gitRef={this.props.line.gitRef} />
         <LogLineText
           lineRefCallback={this.props.lineRefCallback}
@@ -149,7 +157,6 @@ function mapStateToProps(
 ): $Shape<Props> {
   return {
     ...ownProps,
-    shareLine: selectors.getLogViewerShareLine(state),
   };
 }
 

--- a/src/components/LogView/FullLogLine.js
+++ b/src/components/LogView/FullLogLine.js
@@ -103,7 +103,10 @@ class FullLogLine extends React.Component<Props, State> {
             const nextHash = queryString.stringify({
               ...queryString.parseUrl(window.location.href.replace("#", "?"))
                 .query,
-              shareLine: this.props.line.lineNumber,
+              shareLine:
+                this.props.line.lineNumber === this.props.shareLine
+                  ? -1
+                  : this.props.line.lineNumber,
             });
             window.history.replaceState(
               {},

--- a/src/components/LogView/LineNumber.js
+++ b/src/components/LogView/LineNumber.js
@@ -16,7 +16,9 @@ export default class LineNumber extends React.PureComponent<Props> {
         className="padded-text"
         style={style}
         onDoubleClick={this.props.handleDoubleClick}
-      ></span>
+      >
+        {this.props.children ? <span> {this.props.children}</span> : null}
+      </span>
     );
   }
 }

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -291,6 +291,7 @@ class LogView extends React.Component<Props, State> {
       key={lineNumber + ":" + line.isMatched}
       found={lineNumber === this.props.findResults[this.props.searchFindIdx]}
       bookmarked={this.findBookmark(this.props.bookmarks, lineNumber) !== -1}
+      isShareLine={lineNumber === this.props.shareLine}
       highlight={this.props.highlights.highlightLines.includes(line)}
       wrap={this.props.wrap}
       line={line}

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -388,9 +388,11 @@ class LogView extends React.Component<Props, State> {
     } else if (
       this.props.shareLine > -1 &&
       this.state.lines.length > 0 &&
-      prevState.lines.length === 0
+      !this.state.hasScrolledToFirstBookmark
     ) {
-      this.scrollToLine(this.props.shareLine);
+      this.setState({ hasScrolledToFirstBookmark: true }, () => {
+        this.props.scrollToLine(this.props.shareLine);
+      });
     } else if (
       // Only process bookmark scrolling when scroll query param is omitted from URL.
       // Don't scroll unless lines are rendered and bookmarks exist

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -55,7 +55,7 @@ function newSkipLine(start, end): SkipLine {
 }
 
 type State = {
-  hasScrolledToFirstBookmark: boolean,
+  hasScrolledToShareLine: boolean,
   selectStartIndex: ?number,
   selectEndIndex: ?number,
   lines: Array<Line | SkipLine>,
@@ -69,7 +69,7 @@ class LogView extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      hasScrolledToFirstBookmark: props.bookmarks.length === 0,
+      hasScrolledToShareLine: props.bookmarks.length === 0,
       selectStartIndex: null,
       selectEndIndex: null,
       clicks: [],
@@ -388,36 +388,11 @@ class LogView extends React.Component<Props, State> {
     } else if (
       this.props.shareLine > -1 &&
       this.state.lines.length > 0 &&
-      !this.state.hasScrolledToFirstBookmark
+      !this.state.hasScrolledToShareLine
     ) {
-      this.setState({ hasScrolledToFirstBookmark: true }, () => {
+      this.setState({ hasScrolledToShareLine: true }, () => {
         this.props.scrollToLine(this.props.shareLine);
       });
-    } else if (
-      // Only process bookmark scrolling when scroll query param is omitted from URL.
-      // Don't scroll unless lines are rendered and bookmarks exist
-      this.state.lines.length > 0 &&
-      prevState.lines.length === 0 &&
-      this.props.bookmarks.length > 0 &&
-      // Don't scroll when the bookmarks look like [0, last line]
-      !(
-        currBookmarksSet.size === 2 &&
-        currBookmarksSet.has(0) &&
-        currBookmarksSet.has(lastLineNo)
-      ) &&
-      // Don't scroll when we already tried to scroll before lol
-      !this.state.hasScrolledToFirstBookmark
-    ) {
-      const sortedBookmarks = [...this.props.bookmarks].sort(
-        (a, b) => a.lineNumber - b.lineNumber
-      );
-      const { lineNumber } =
-        sortedBookmarks.find(({ lineNumber }) => lineNumber !== 0) || {};
-      if (lineNumber !== undefined) {
-        this.setState({ hasScrolledToFirstBookmark: true }, () => {
-          this.props.scrollToLine(lineNumber);
-        });
-      }
     }
 
     // If the find index changed, scroll to the right if necessary.

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -68,7 +68,6 @@ class LogView extends React.Component<Props, State> {
   lineMap: Map<number, HTMLSpanElement> = new Map();
   constructor(props) {
     super(props);
-    console.log("shareline", props.shareLine);
     this.state = {
       hasScrolledToFirstBookmark: props.bookmarks.length === 0,
       selectStartIndex: null,

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -40,6 +40,7 @@ type Props = {
   scrollToLine: (number) => void,
   prettyPrint: boolean,
   toggleWrap: () => void,
+  shareLine: number,
 };
 
 type SkipLine = {|
@@ -65,9 +66,9 @@ type State = {
 class LogView extends React.Component<Props, State> {
   logListRef: ?ReactList = null;
   lineMap: Map<number, HTMLSpanElement> = new Map();
-
   constructor(props) {
     super(props);
+    console.log("shareline", props.shareLine);
     this.state = {
       hasScrolledToFirstBookmark: props.bookmarks.length === 0,
       selectStartIndex: null,
@@ -379,6 +380,19 @@ class LogView extends React.Component<Props, State> {
     const lastLineNo = this.state.lines.length - 1;
     // handle initial bookmark scroll
     if (
+      this.props.scrollLine !== null &&
+      this.props.scrollLine !== prevProps.scrollLine &&
+      this.state.lines.length > 0
+    ) {
+      this.scrollToLine(this.props.scrollLine);
+    } else if (
+      this.props.shareLine > -1 &&
+      this.state.lines.length > 0 &&
+      prevState.lines.length === 0
+    ) {
+      this.scrollToLine(this.props.shareLine);
+    } else if (
+      // Only process bookmark scrolling when scroll query param is omitted from URL.
       // Don't scroll unless lines are rendered and bookmarks exist
       this.state.lines.length > 0 &&
       prevState.lines.length === 0 &&
@@ -402,14 +416,6 @@ class LogView extends React.Component<Props, State> {
           this.props.scrollToLine(lineNumber);
         });
       }
-    }
-
-    if (
-      this.props.scrollLine !== null &&
-      this.props.scrollLine >= 0 &&
-      this.props.scrollLine !== prevProps.scrollLine
-    ) {
-      this.scrollToLine(this.props.scrollLine);
     }
 
     // If the find index changed, scroll to the right if necessary.
@@ -474,6 +480,7 @@ function mapStateToProps(
     lines: lines,
     findResults: selectors.getFindResults(state),
     expandableFilterData: [],
+    shareLine: selectors.getLogViewerShareLine(state),
   };
 }
 

--- a/src/components/LogView/style.css
+++ b/src/components/LogView/style.css
@@ -1,4 +1,5 @@
 .bookmark-line { background-color: #ffffb3; }
+.share-line { background-color: #FFD9B3 !important;}
 .highlighted { background-color: #fff0f2; }
 .filtered { background-color: #ffdde3; }
 .no-match { background-color: #e8e7d9; }

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import "whatwg-fetch";
 const saga = createSagaMiddleware();
 const middlewares = [saga];
 if (!isProd) {
-  //middlewares.push(logger);
+  middlewares.push(logger);
 }
 
 const store = createStore(lobster, applyMiddleware(...middlewares));

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import "whatwg-fetch";
 const saga = createSagaMiddleware();
 const middlewares = [saga];
 if (!isProd) {
-  middlewares.push(logger);
+  //middlewares.push(logger);
 }
 
 const store = createStore(lobster, applyMiddleware(...middlewares));

--- a/src/models.js
+++ b/src/models.js
@@ -310,6 +310,7 @@ export type LogViewerState = $Exact<
     settings: Settings,
     settingsPanel: boolean,
     scrollLine: number,
+    shareLine: number,
   }>
 >;
 

--- a/src/reducers/logviewer/bookmarks.js
+++ b/src/reducers/logviewer/bookmarks.js
@@ -35,7 +35,9 @@ export default function (
   action: Action
 ): Bookmark[] {
   if (action.type === LOGVIEWER_LOAD_BOOKMARKS) {
-    return action.payload.bookmarksArr;
+    const clone = [...action.payload.bookmarksArr];
+    clone.sort((a, b) => a.lineNumber - b.lineNumber);
+    return clone;
   }
 
   if (action.type === LOGVIEWER_ENSURE_BOOKMARK) {

--- a/src/reducers/logviewer/index.js
+++ b/src/reducers/logviewer/index.js
@@ -7,6 +7,8 @@ import find from "./find";
 import settings from "./settings";
 import settingsPanel from "./settingsPanel";
 import scrollLine from "./scrollLine";
+import shareLine from "./shareLine";
+
 import { combineReducers } from "redux";
 
 export default combineReducers({
@@ -17,4 +19,5 @@ export default combineReducers({
   settings: settings,
   settingsPanel: settingsPanel,
   scrollLine: scrollLine,
+  shareLine: shareLine,
 });

--- a/src/reducers/logviewer/shareLine.js
+++ b/src/reducers/logviewer/shareLine.js
@@ -3,5 +3,8 @@
 import { type Action, LOGVIEWER_LOAD_SHARE_LINE } from "../../actions";
 
 export default function (state: number = -1, action: Action): number {
+  if (action.type === LOGVIEWER_LOAD_SHARE_LINE) {
+    return action.payload.lineNum;
+  }
   return state;
 }

--- a/src/reducers/logviewer/shareLine.js
+++ b/src/reducers/logviewer/shareLine.js
@@ -1,0 +1,7 @@
+// @flow strict
+
+import { type Action, LOGVIEWER_LOAD_SHARE_LINE } from "../../actions";
+
+export default function (state: number = -1, action: Action): number {
+  return state;
+}

--- a/src/sagas/updateURL.js
+++ b/src/sagas/updateURL.js
@@ -36,6 +36,7 @@ export default function* (): Saga<void> {
   const highlights = yield select(selectors.getLogViewerHighlights);
   const bookmarks = yield select(selectors.getLogViewerBookmarks);
   const settings = yield select(selectors.getLogViewerSettings);
+  const shareLine = yield select(selectors.getLogViewerShareLine);
 
   const parsed = {};
   parsed["f~"] = [];
@@ -86,6 +87,9 @@ export default function* (): Saga<void> {
     parsed.l = boolToInt(true);
   }
 
+  if (shareLine > -1) {
+    parsed.shareLine = shareLine;
+  }
   if (Object.keys(parsed).length !== 0) {
     try {
       window.history.replaceState(

--- a/src/sagas/urlParse.js
+++ b/src/sagas/urlParse.js
@@ -9,6 +9,7 @@ import {
   loadBookmarks,
   loadInitialFilters,
   loadInitialHighlights,
+  loadShareLine,
 } from "../actions";
 import { put, select } from "redux-saga/effects";
 import type { Saga } from "redux-saga";
@@ -19,6 +20,7 @@ export default function* (): Saga<void> {
   yield put(
     loadBookmarks([...urlData.bookmarks].map((n) => ({ lineNumber: n })))
   );
+  yield put(loadShareLine(urlData.shareLine));
   yield put(loadInitialFilters([...urlData.filters]));
   yield put(loadInitialHighlights([...urlData.highlights]));
 

--- a/src/selectors/basic.js
+++ b/src/selectors/basic.js
@@ -16,6 +16,8 @@ export const getLogViewerHighlights = (state: ReduxState) =>
   getLogViewer(state).highlights;
 export const getLogViewerBookmarks = (state: ReduxState) =>
   getLogViewer(state).bookmarks;
+const getLogViewerShareLine = (state: ReduxState) =>
+  getLogViewer(state).shareLine;
 
 export const getLogViewerFind = (state: ReduxState) => getLogViewer(state).find;
 export const getLogViewerFindIdx = (state: ReduxState) =>

--- a/src/selectors/basic.js
+++ b/src/selectors/basic.js
@@ -16,7 +16,7 @@ export const getLogViewerHighlights = (state: ReduxState) =>
   getLogViewer(state).highlights;
 export const getLogViewerBookmarks = (state: ReduxState) =>
   getLogViewer(state).bookmarks;
-const getLogViewerShareLine = (state: ReduxState) =>
+export const getLogViewerShareLine = (state: ReduxState) =>
   getLogViewer(state).shareLine;
 
 export const getLogViewerFind = (state: ReduxState) => getLogViewer(state).find;

--- a/src/selectors/lines/filter.js
+++ b/src/selectors/lines/filter.js
@@ -54,9 +54,13 @@ export const shouldPrintLine = function (
   bookmarks: Bookmark[],
   filterIntersection: boolean,
   filter: RegExp[],
-  inverseFilter: RegExp[]
+  inverseFilter: RegExp[],
+  shareLine: number
 ): boolean {
-  if (findBookmark(bookmarks, line.lineNumber) !== -1) {
+  if (
+    findBookmark(bookmarks, line.lineNumber) !== -1 ||
+    shareLine === line.lineNumber
+  ) {
     return true;
   }
 
@@ -102,12 +106,14 @@ const getFilteredLineData = createSelector(
   selectors.getLogViewerBookmarks,
   selectors.getLogViewerSettingsFilterLogic,
   selectors.getLogViewerSettingsParseJson,
+  selectors.getLogViewerShareLine,
   function (
     lines: Line[],
     filters: Filter[],
     bookmarks: Bookmark[],
     filterIntersection: boolean,
-    parseResmokeJson: boolean
+    parseResmokeJson: boolean,
+    shareLine: number
   ): Line[] {
     const filter = merge.activeFilters(filters);
     const inverseFilter = merge.activeInverseFilters(filters);
@@ -118,7 +124,8 @@ const getFilteredLineData = createSelector(
           bookmarks,
           filterIntersection,
           filter,
-          inverseFilter
+          inverseFilter,
+          shareLine
         )
       ) {
         line.isMatched = false;

--- a/src/urlParse.js
+++ b/src/urlParse.js
@@ -201,6 +201,7 @@ export default function (
   const bookmarks: Set<number> = new Set([
     ...parseBookmarks(hash.query.bookmarks),
     ...parseBookmarks(query.query.bookmarks),
+    ...(shareLine > -1 ? [shareLine] : []),
   ]);
 
   let scroll = parseInt(hash.query.scroll || query.query.scroll, 10);

--- a/src/urlParse.js
+++ b/src/urlParse.js
@@ -201,7 +201,6 @@ export default function (
   const bookmarks: Set<number> = new Set([
     ...parseBookmarks(hash.query.bookmarks),
     ...parseBookmarks(query.query.bookmarks),
-    ...(shareLine > -1 ? [shareLine] : []),
   ]);
 
   let scroll = parseInt(hash.query.scroll || query.query.scroll, 10);

--- a/src/urlParse.js
+++ b/src/urlParse.js
@@ -3,6 +3,10 @@
 import queryString from "./thirdparty/query-string";
 import type { Filter, Highlight } from "./models";
 
+function parseShareLine(shareLine: ?string): number {
+  const parsed = parseInt(shareLine, 10);
+  return isNaN(parsed) ? -1 : parsed;
+}
 function parseBookmarks(bookmarks: ?string): Set<number> {
   if (bookmarks == null) {
     return new Set();
@@ -176,6 +180,7 @@ export type URLParseData = $Exact<
     url: ?string,
     caseSensitive: ?boolean,
     filterIsIntersection: ?boolean,
+    shareLine: number,
   }>
 >;
 
@@ -192,7 +197,7 @@ export default function (
     arrayify(obj.query, "h");
     arrayify(obj.query, "h~");
   });
-
+  const shareLine = parseShareLine(hash.query.shareLine);
   const bookmarks: Set<number> = new Set([
     ...parseBookmarks(hash.query.bookmarks),
     ...parseBookmarks(query.query.bookmarks),
@@ -223,5 +228,6 @@ export default function (
     url,
     caseSensitive: charToBool(hash.query.c),
     filterIsIntersection: charToBool(hash.query.l),
+    shareLine,
   };
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-14188

reinstall node modules to get this PR to run properly. 
navigate to http://localhost:3000/lobster/evergreen/task/evergreen_ubuntu1604_test_graphql_patch_29ab59687b2dcff93f3530d1d8571c7830cb8bd8_604650a3a4cf471076131dea_21_03_08_16_28_21/0/agent

Clicking on the link icon to the left of the line number adds a "shareline" to the bookmark column. The shareline takes precedence during the initial page load/scroll.

Only one shareline can be enabled at once. Selecting a new shareline will replace the old one, unless you are open a link that already contains a shareline. In this case, the shareline is preserved as a bookmark. 