### PR TITLE
EVG-14100: Render test logs 

### DIFF
--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -59,13 +59,25 @@ export function taskURL(taskID: string, execution: ?number): string {
   return base + `/${execution}`;
 }
 
+const getTestMetadataURL = ({
+  taskId,
+  execution,
+  testId,
+}: {
+  taskId: string,
+  execution: number,
+  testId: string,
+}) =>
+  `${EVERGREEN_BASE}/rest/v2/tasks/${taskId}/tests?execution=${execution}&test_id=${testId}`;
+
 export async function fetchEvergreen(log: EvergreenLog): Promise<Response> {
   const init = { method: "GET", credentials: "include" };
   let req = "";
   if (log.type === "evergreen-task") {
     req = new Request(taskLogRawURL(log.id, log.execution, log.log), init);
   } else if (log.type === "evergreen-test") {
-    const testMetadataUrl = `${EVERGREEN_BASE}/rest/v2/tasks/${log.taskId}/tests?execution=${log.execution}&test_id=${log.testId}`;
+    const { taskId, testId, execution } = log;
+    const testMetadataUrl = getTestMetadataURL({ execution, taskId, testId });
     const testMetadataReq = new Request(testMetadataUrl);
     const res = await window.fetch(testMetadataReq, {
       credentials: "include",

--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -66,7 +66,7 @@ export async function fetchEvergreen(log: EvergreenLog): Promise<Response> {
     req = new Request(taskLogRawURL(log.id, log.execution, log.log), init);
   } else if (log.type === "evergreen-test") {
     const evgAPITestReq = new Request(
-      `${EVERGREEN_BASE}/rest/v2/tasks/${log.taskId}/tests?execution=${log.execution}&test_name=${log.testId}`
+      `${EVERGREEN_BASE}/rest/v2/tasks/${log.taskId}/tests?execution=${log.execution}&test_name=${log.testfile}`
     );
     const res = await window.fetch(evgAPITestReq, {
       credentials: "include",

--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -28,10 +28,9 @@ export function testLogURL(id: string): string {
 export function testLogRawURL(
   id: string,
   taskId: string,
-  execution: string,
-  groupId: string
+  execution: string
 ): string {
-  return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}/${id}?text=true&group_id=${groupId}`;
+  return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}/${id}?text=true`;
 }
 
 export function testLogByNameURL(
@@ -60,14 +59,23 @@ export function taskURL(taskID: string, execution: ?number): string {
   return base + `/${execution}`;
 }
 
-export function fetchEvergreen(log: EvergreenLog): Promise<Response> {
+export async function fetchEvergreen(log: EvergreenLog): Promise<Response> {
   const init = { method: "GET", credentials: "include" };
   let req;
   if (log.type === "evergreen-task") {
     req = new Request(taskLogRawURL(log.id, log.execution, log.log), init);
   } else if (log.type === "evergreen-test") {
+    const evgAPITestReq = new Request(
+      `${EVERGREEN_BASE}/rest/v2/tasks/${log.taskId}/tests?execution=${log.execution}&test_name=${log.testfile}`
+    );
+    const res = await window.fetch(evgAPITestReq, {
+      credentials: "include",
+    });
+    console.log(res);
+
     req = new Request(
-      testLogRawURL(log.id, log.taskId, log.execution, log.groupId),
+      "lol",
+      //testLogRawURL(log.id, log.taskId, log.execution, log.groupId),
       init
     );
   } else if (log.type === "evergreen-test-by-name") {

--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -66,7 +66,7 @@ export async function fetchEvergreen(log: EvergreenLog): Promise<Response> {
     req = new Request(taskLogRawURL(log.id, log.execution, log.log), init);
   } else if (log.type === "evergreen-test") {
     const evgAPITestReq = new Request(
-      `${EVERGREEN_BASE}/rest/v2/tasks/${log.taskId}/tests?execution=${log.execution}&test_name=${log.testfile}`
+      `${EVERGREEN_BASE}/rest/v2/tasks/${log.taskId}/tests?execution=${log.execution}&test_name=${log.testId}`
     );
     const res = await window.fetch(evgAPITestReq, {
       credentials: "include",

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -48,7 +48,7 @@ const Main = () => (
       />
       <Route
         exact
-        path="/lobster/evergreen/test/:taskId/:execution/:testfile/:id"
+        path="/lobster/evergreen/test/:taskId/:execution/:testId/:id"
         render={evergreenLogviewer}
       />
       <Route

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -48,7 +48,7 @@ const Main = () => (
       />
       <Route
         exact
-        path="/lobster/evergreen/test/:taskId/:execution/:testId/:id"
+        path="/lobster/evergreen/test/:taskId/:execution/:testfile/:id"
         render={evergreenLogviewer}
       />
       <Route

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -43,17 +43,12 @@ const Main = () => (
       <Route path="/lobster/build/:build/all" render={logviewer} />
       <Route
         exact
-        path="/lobster/evergreen/task/:id/:execution/:type"
+        path="/lobster/evergreen/task/:taskId/:execution/:logType"
         render={evergreenLogviewer}
       />
       <Route
         exact
-        path="/lobster/evergreen/test/:taskId/:execution/:testfile/:id"
-        render={evergreenLogviewer}
-      />
-      <Route
-        exact
-        path="/lobster/evergreen/test/:id/:execution/:type"
+        path="/lobster/evergreen/test/:taskId/:execution/:testId"
         render={evergreenLogviewer}
       />
       <Route path="/lobster/logdrop" render={logviewer} />

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -48,7 +48,7 @@ const Main = () => (
       />
       <Route
         exact
-        path="/lobster/evergreen/test/:taskId/:execution/:id/:groupId"
+        path="/lobster/evergreen/test/:taskId/:execution/:testfile/:id"
         render={evergreenLogviewer}
       />
       <Route

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import type { Node as ReactNode } from "react";
-import { getTestMetadata } from "../../util";
+import { getTestMetadata, type TestMetadata } from "../../util";
 import { EVERGREEN_BASE } from "../../config";
 import "./style.css";
 import {
@@ -67,6 +67,9 @@ type Props = {
   changeStartRange: (value: number) => void,
   changeEndRange: (value: number) => void,
 };
+type State = {|
+  testMetadata: ?TestMetadata,
+|};
 
 function showLogBox(
   id: ?LogIdentity,
@@ -98,7 +101,7 @@ function showLogBox(
 function showDetailButtons(
   id: ?LogIdentity,
   clearCache: ?() => void,
-  testMetadata: any
+  testMetadata: TestMetadata
 ): ?ReactNode {
   if (!id) {
     return null;
@@ -247,7 +250,7 @@ function showDetailButtons(
   return <span>{buttons}</span>;
 }
 
-export class CollapseMenu extends React.PureComponent<Props> {
+export class CollapseMenu extends React.PureComponent<Props, State> {
   urlInput: ?HTMLInputElement;
   startRangeInput: ?HTMLInputElement;
   endRangeInput: ?HTMLInputElement;

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -314,7 +314,6 @@ export class CollapseMenu extends React.PureComponent<Props> {
     }
   }
   render() {
-    console.log(this.state);
     return (
       <Collapse className="collapse-menu" in={this.props.detailsOpen}>
         <div>

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -2,6 +2,8 @@
 
 import React from "react";
 import type { Node as ReactNode } from "react";
+import { getTestMetadata } from "../../util";
+import { EVERGREEN_BASE } from "../../config";
 import "./style.css";
 import {
   Button,
@@ -95,7 +97,8 @@ function showLogBox(
 
 function showDetailButtons(
   id: ?LogIdentity,
-  clearCache: ?() => void
+  clearCache: ?() => void,
+  testMetadata: any
 ): ?ReactNode {
   if (!id) {
     return null;
@@ -181,20 +184,30 @@ function showDetailButtons(
       ]
     );
   } else if (id.type === "evergreen-test") {
-    buttons.push(
-      ...[
-        <Col key={1} lg={1}>
-          <Button style={col0Style} href={api.testLogRawURL(id.id)}>
-            Raw
-          </Button>
-        </Col>,
-        <Col key={2} lg={1}>
-          <Button style={col1Style} href={api.testLogURL(id.id)}>
-            HTML
-          </Button>
-        </Col>,
-      ]
-    );
+    const { logs } = testMetadata || {};
+    const { url_html_display, url_raw_display } = logs || {};
+    if (url_html_display && url_raw_display) {
+      buttons.push(
+        ...[
+          <Col key={1} lg={1}>
+            <Button
+              style={col0Style}
+              href={`${EVERGREEN_BASE}/${url_raw_display}`}
+            >
+              Raw
+            </Button>
+          </Col>,
+          <Col key={2} lg={1}>
+            <Button
+              style={col1Style}
+              href={`${EVERGREEN_BASE}/${url_html_display}`}
+            >
+              HTML
+            </Button>
+          </Col>,
+        ]
+      );
+    }
   } else if (id.type === "evergreen-test-by-name") {
     buttons.push(
       ...[
@@ -238,7 +251,10 @@ export class CollapseMenu extends React.PureComponent<Props> {
   urlInput: ?HTMLInputElement;
   startRangeInput: ?HTMLInputElement;
   endRangeInput: ?HTMLInputElement;
-
+  constructor(props) {
+    super(props);
+    this.state = { testMetadata: null };
+  }
   setURLRef = (ref: ?HTMLInputElement) => {
     this.urlInput = ref;
   };
@@ -285,7 +301,20 @@ export class CollapseMenu extends React.PureComponent<Props> {
     this.endRangeInput = ref;
   };
 
+  componentDidUpdate(prevProps: Props) {
+    if (
+      this.props.logIdentity &&
+      this.props.logIdentity.type === "evergreen-test" &&
+      !this.state.testMetadata
+    ) {
+      const { execution, testId, taskId } = this.props.logIdentity;
+      getTestMetadata({ execution, testId, taskId }).then((data) =>
+        this.setState({ testMetadata: data })
+      );
+    }
+  }
   render() {
+    console.log(this.state);
     return (
       <Collapse className="collapse-menu" in={this.props.detailsOpen}>
         <div>
@@ -446,7 +475,11 @@ export class CollapseMenu extends React.PureComponent<Props> {
                   value={this.props.valueJIRA}
                 ></textarea>
               </Col>
-              {showDetailButtons(this.props.logIdentity, this.props.wipeCache)}
+              {showDetailButtons(
+                this.props.logIdentity,
+                this.props.wipeCache,
+                this.state.testMetadata
+              )}
             </FormGroup>
           </Form>
           <Filters

--- a/src/components/Fetch/EvergreenLogViewer.js
+++ b/src/components/Fetch/EvergreenLogViewer.js
@@ -5,48 +5,28 @@ import Fetch from ".";
 import { stringToEvergreenTaskLogType, type LogIdentity } from "../../models";
 import type { ContextRouter } from "react-router-dom";
 
-function makeEvergreenLogID(
-  isTest: boolean,
-  id: ?string,
-  type: ?string,
+function makeEvergreenLogID(params: {
+  logType: ?string,
   execution: ?string,
-  groupId: ?string,
+  testId: ?string,
   taskId: ?string,
-  testfile: ?string
-): ?LogIdentity {
-  if (id == null) {
-    return null;
-  }
-
+}): ?LogIdentity {
+  const { logType, execution, testId, taskId } = params;
   const executionAsNumber = parseInt(execution, 10) || 0;
 
-  if (type != null) {
-    if (isTest) {
-      return {
-        type: "evergreen-test-by-name",
-        task: id,
-        execution: executionAsNumber,
-        test: type,
-      };
-    }
-    const logType = stringToEvergreenTaskLogType(type);
-    if (logType == null) {
-      return null;
-    }
+  if (logType != null) {
     return {
       type: "evergreen-task",
-      id: id,
+      id: taskId || "",
       execution: executionAsNumber,
-      log: logType,
+      log: stringToEvergreenTaskLogType(logType),
     };
   }
 
   return {
     type: "evergreen-test",
-    testfile: testfile || "",
-    testId: id,
+    testId: testId || "",
     execution: executionAsNumber,
-    groupId: groupId || "",
     taskId: taskId || "",
   };
 }
@@ -60,16 +40,7 @@ const EvergreenLogViewer = (props: ContextRouter) => {
     const line = matches[1];
     newProps.location.hash = `#scroll=${line}&bookmarks=${line}`;
   }
-  const { id, type, execution, taskId, groupId, testfile } = props.match.params;
-  const logID = makeEvergreenLogID(
-    props.location.pathname.startsWith("/lobster/evergreen/test/"),
-    id,
-    type,
-    execution,
-    groupId,
-    taskId,
-    testfile
-  );
+  const logID = makeEvergreenLogID(props.match.params);
 
   return <Fetch {...newProps} logIdentity={logID} />;
 };

--- a/src/components/Fetch/EvergreenLogViewer.js
+++ b/src/components/Fetch/EvergreenLogViewer.js
@@ -12,7 +12,7 @@ function makeEvergreenLogID(
   execution: ?string,
   groupId: ?string,
   taskId: ?string,
-  testfile: ?string
+  testId: ?string
 ): ?LogIdentity {
   if (id == null) {
     return null;
@@ -43,7 +43,7 @@ function makeEvergreenLogID(
 
   return {
     type: "evergreen-test",
-    testfile: testfile || "",
+    testId: testId || "",
     testId: id,
     execution: executionAsNumber,
     groupId: groupId || "",
@@ -60,7 +60,7 @@ const EvergreenLogViewer = (props: ContextRouter) => {
     const line = matches[1];
     newProps.location.hash = `#scroll=${line}&bookmarks=${line}`;
   }
-  const { id, type, execution, taskId, groupId, testfile } = props.match.params;
+  const { id, type, execution, taskId, groupId, testId } = props.match.params;
   const logID = makeEvergreenLogID(
     props.location.pathname.startsWith("/lobster/evergreen/test/"),
     id,
@@ -68,7 +68,7 @@ const EvergreenLogViewer = (props: ContextRouter) => {
     execution,
     groupId,
     taskId,
-    testfile
+    testId
   );
 
   return <Fetch {...newProps} logIdentity={logID} />;

--- a/src/components/Fetch/EvergreenLogViewer.js
+++ b/src/components/Fetch/EvergreenLogViewer.js
@@ -14,7 +14,7 @@ function makeEvergreenLogID(params: {
   const { logType, execution, testId, taskId } = params;
   const executionAsNumber = parseInt(execution, 10) || 0;
 
-  if (logType != null) {
+  if (logType) {
     return {
       type: "evergreen-task",
       id: taskId || "",

--- a/src/components/Fetch/EvergreenLogViewer.js
+++ b/src/components/Fetch/EvergreenLogViewer.js
@@ -12,7 +12,7 @@ function makeEvergreenLogID(
   execution: ?string,
   groupId: ?string,
   taskId: ?string,
-  testId: ?string
+  testfile: ?string
 ): ?LogIdentity {
   if (id == null) {
     return null;
@@ -43,7 +43,7 @@ function makeEvergreenLogID(
 
   return {
     type: "evergreen-test",
-    testId: testId || "",
+    testfile: testfile || "",
     testId: id,
     execution: executionAsNumber,
     groupId: groupId || "",
@@ -60,7 +60,7 @@ const EvergreenLogViewer = (props: ContextRouter) => {
     const line = matches[1];
     newProps.location.hash = `#scroll=${line}&bookmarks=${line}`;
   }
-  const { id, type, execution, taskId, groupId, testId } = props.match.params;
+  const { id, type, execution, taskId, groupId, testfile } = props.match.params;
   const logID = makeEvergreenLogID(
     props.location.pathname.startsWith("/lobster/evergreen/test/"),
     id,
@@ -68,7 +68,7 @@ const EvergreenLogViewer = (props: ContextRouter) => {
     execution,
     groupId,
     taskId,
-    testId
+    testfile
   );
 
   return <Fetch {...newProps} logIdentity={logID} />;

--- a/src/components/Fetch/EvergreenLogViewer.js
+++ b/src/components/Fetch/EvergreenLogViewer.js
@@ -11,7 +11,8 @@ function makeEvergreenLogID(
   type: ?string,
   execution: ?string,
   groupId: ?string,
-  taskId: ?string
+  taskId: ?string,
+  testfile: ?string
 ): ?LogIdentity {
   if (id == null) {
     return null;
@@ -42,7 +43,8 @@ function makeEvergreenLogID(
 
   return {
     type: "evergreen-test",
-    id,
+    testfile: testfile || "",
+    testId: id,
     execution: executionAsNumber,
     groupId: groupId || "",
     taskId: taskId || "",
@@ -58,14 +60,15 @@ const EvergreenLogViewer = (props: ContextRouter) => {
     const line = matches[1];
     newProps.location.hash = `#scroll=${line}&bookmarks=${line}`;
   }
-  const { id, type, execution, taskId, groupId } = props.match.params;
+  const { id, type, execution, taskId, groupId, testfile } = props.match.params;
   const logID = makeEvergreenLogID(
     props.location.pathname.startsWith("/lobster/evergreen/test/"),
     id,
     type,
     execution,
     groupId,
-    taskId
+    taskId,
+    testfile
   );
 
   return <Fetch {...newProps} logIdentity={logID} />;

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import "whatwg-fetch";
 const saga = createSagaMiddleware();
 const middlewares = [saga];
 if (!isProd) {
-  //middlewares.push(logger);
+  middlewares.push(logger);
 }
 
 const store = createStore(lobster, applyMiddleware(...middlewares));

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import "whatwg-fetch";
 const saga = createSagaMiddleware();
 const middlewares = [saga];
 if (!isProd) {
-  middlewares.push(logger);
+  //middlewares.push(logger);
 }
 
 const store = createStore(lobster, applyMiddleware(...middlewares));

--- a/src/models.js
+++ b/src/models.js
@@ -196,13 +196,10 @@ export function stringToInteralEvergreenTaskLogType(a: ?string): ?string {
   return evergreenTaskLogTypes[a];
 }
 
-export function stringToEvergreenTaskLogType(
-  a: ?string
-): ?EvergreenTaskLogType {
+export function stringToEvergreenTaskLogType(a: ?string): EvergreenTaskLogType {
   if (a == null || !(a in evergreenTaskLogTypes)) {
-    return null;
+    return evergreenTaskLogTypes.all;
   }
-
   return a;
 }
 
@@ -215,7 +212,6 @@ export type EvergreenTaskLog = $ReadOnly<{
 
 export type EvergreenTestLog = $ReadOnly<{
   type: "evergreen-test",
-  testfile: string,
   taskId: string,
   execution: number,
   testId: string,

--- a/src/models.js
+++ b/src/models.js
@@ -215,7 +215,7 @@ export type EvergreenTaskLog = $ReadOnly<{
 
 export type EvergreenTestLog = $ReadOnly<{
   type: "evergreen-test",
-  testId: string,
+  testfile: string,
   taskId: string,
   execution: number,
   testId: string,

--- a/src/models.js
+++ b/src/models.js
@@ -215,7 +215,7 @@ export type EvergreenTaskLog = $ReadOnly<{
 
 export type EvergreenTestLog = $ReadOnly<{
   type: "evergreen-test",
-  testfile: string,
+  testId: string,
   taskId: string,
   execution: number,
   testId: string,

--- a/src/models.js
+++ b/src/models.js
@@ -215,10 +215,10 @@ export type EvergreenTaskLog = $ReadOnly<{
 
 export type EvergreenTestLog = $ReadOnly<{
   type: "evergreen-test",
-  id: string,
+  testfile: string,
   taskId: string,
-  groupId: string,
   execution: number,
+  testId: string,
 }>;
 
 export type EvergreenTestByNameLog = $ReadOnly<{

--- a/src/sagas/logfetchers.js
+++ b/src/sagas/logfetchers.js
@@ -80,7 +80,7 @@ export function* evergreenLoadData(identity: EvergreenLog): Saga<void> {
   console.info(`fetch (evergreen) ${JSON.stringify(identity)}`);
   // DO NOT cache Evergreen task logs without checking if the task is done
   if (identity.type === "evergreen-test") {
-    const f = `fetchEvergreen-test-${identity.id}.json`;
+    const f = `fetchEvergreen-test-${identity.testfile}.json`;
     yield cacheFetch(f, "raw", api.fetchEvergreen, identity);
     return;
   } else if (identity.type === "evergreen-test-by-name") {

--- a/src/sagas/logfetchers.js
+++ b/src/sagas/logfetchers.js
@@ -80,7 +80,7 @@ export function* evergreenLoadData(identity: EvergreenLog): Saga<void> {
   console.info(`fetch (evergreen) ${JSON.stringify(identity)}`);
   // DO NOT cache Evergreen task logs without checking if the task is done
   if (identity.type === "evergreen-test") {
-    const f = `fetchEvergreen-test-${identity.testfile}.json`;
+    const f = `fetchEvergreen-test-${identity.testId}.json`;
     yield cacheFetch(f, "raw", api.fetchEvergreen, identity);
     return;
   } else if (identity.type === "evergreen-test-by-name") {

--- a/src/sagas/logfetchers.js
+++ b/src/sagas/logfetchers.js
@@ -80,7 +80,7 @@ export function* evergreenLoadData(identity: EvergreenLog): Saga<void> {
   console.info(`fetch (evergreen) ${JSON.stringify(identity)}`);
   // DO NOT cache Evergreen task logs without checking if the task is done
   if (identity.type === "evergreen-test") {
-    const f = `fetchEvergreen-test-${JSON.stringify(identity)}.json`;
+    const f = `fetchEvergreen-test-${identity.taskId}-${identity.execution}-${identity.testId}.json`;
     yield cacheFetch(f, "raw", api.fetchEvergreen, identity);
     return;
   } else if (identity.type === "evergreen-test-by-name") {

--- a/src/sagas/logfetchers.js
+++ b/src/sagas/logfetchers.js
@@ -80,7 +80,7 @@ export function* evergreenLoadData(identity: EvergreenLog): Saga<void> {
   console.info(`fetch (evergreen) ${JSON.stringify(identity)}`);
   // DO NOT cache Evergreen task logs without checking if the task is done
   if (identity.type === "evergreen-test") {
-    const f = `fetchEvergreen-test-${identity.testfile}.json`;
+    const f = `fetchEvergreen-test-${JSON.stringify(identity)}.json`;
     yield cacheFetch(f, "raw", api.fetchEvergreen, identity);
     return;
   } else if (identity.type === "evergreen-test-by-name") {

--- a/src/sagas/logfetchers.js
+++ b/src/sagas/logfetchers.js
@@ -80,7 +80,7 @@ export function* evergreenLoadData(identity: EvergreenLog): Saga<void> {
   console.info(`fetch (evergreen) ${JSON.stringify(identity)}`);
   // DO NOT cache Evergreen task logs without checking if the task is done
   if (identity.type === "evergreen-test") {
-    const f = `fetchEvergreen-test-${identity.testId}.json`;
+    const f = `fetchEvergreen-test-${identity.testfile}.json`;
     yield cacheFetch(f, "raw", api.fetchEvergreen, identity);
     return;
   } else if (identity.type === "evergreen-test-by-name") {

--- a/src/util.js
+++ b/src/util.js
@@ -23,18 +23,20 @@ export const getTestMetadata = async ({
 }) => {
   const testMetadataUrl = getTestMetadataURL({ execution, taskId, testId });
   const testMetadataReq = new Request(testMetadataUrl);
-  const res = await window.fetch(testMetadataReq, {
-    credentials: "include",
-  });
-  const data = await res.json();
-  if (Array.isArray(data) && data.length) {
-    if (data.length > 1) {
-      console.error(
-        "Multiple results error: multiple results came back from the rest v2 tests endpoint instead of 1. Url:",
-        testMetadataUrl
-      );
+  try {
+    const res = await window.fetch(testMetadataReq, {
+      credentials: "include",
+    });
+    const data = await res.json();
+    if (Array.isArray(data) && data.length) {
+      if (data.length > 1) {
+        console.error(
+          "Multiple results error: multiple results came back from the rest v2 tests endpoint instead of 1. Url:",
+          testMetadataUrl
+        );
+      }
+      return data[0];
     }
-    return data[0];
-  }
-  return {};
+  } catch (e) {}
+  return { logs: {} };
 };

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,30 @@
 // @flow strict
 import { EVERGREEN_BASE } from "./config";
+export type TestMetadata = $ReadOnly<
+  $Exact<{
+    base_status?: ?string,
+    duration?: number,
+    end_time?: string,
+    execution?: number,
+    exit_code?: number,
+    line_num?: number,
+    logs: $ReadOnly<
+      $Exact<{
+        line_num?: string,
+        log_id?: string,
+        url?: string,
+        url_html_display?: string,
+        url_raw?: string,
+        url_raw_display?: string,
+      }>
+    >,
+    start_time?: string,
+    status?: string,
+    task_id?: string,
+    test_file?: string,
+    test_id?: string,
+  }>
+>;
 
 const getTestMetadataURL = ({
   taskId,
@@ -20,7 +45,7 @@ export const getTestMetadata = async ({
   taskId: string,
   testId: string,
   execution: number,
-}) => {
+}): Promise<TestMetadata | void> => {
   const testMetadataUrl = getTestMetadataURL({ execution, taskId, testId });
   const testMetadataReq = new Request(testMetadataUrl);
   try {

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,40 @@
+// @flow strict
+import { EVERGREEN_BASE } from "./config";
+
+const getTestMetadataURL = ({
+  taskId,
+  execution,
+  testId,
+}: {
+  taskId: string,
+  execution: number,
+  testId: string,
+}) =>
+  `${EVERGREEN_BASE}/rest/v2/tasks/${taskId}/tests?execution=${execution}&test_id=${testId}`;
+
+export const getTestMetadata = async ({
+  taskId,
+  testId,
+  execution,
+}: {
+  taskId: string,
+  testId: string,
+  execution: number,
+}) => {
+  const testMetadataUrl = getTestMetadataURL({ execution, taskId, testId });
+  const testMetadataReq = new Request(testMetadataUrl);
+  const res = await window.fetch(testMetadataReq, {
+    credentials: "include",
+  });
+  const data = await res.json();
+  if (Array.isArray(data) && data.length) {
+    if (data.length > 1) {
+      console.error(
+        "Multiple results error: multiple results came back from the rest v2 tests endpoint instead of 1. Url:",
+        testMetadataUrl
+      );
+    }
+    return data[0];
+  }
+  return {};
+};


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-14100

the pathname for test logs is `/lobster/evergreen/test/{taskId}/{execution}/{testId}`

checkout these links that load test logs from prod after running `npm run start`:

http://localhost:3000/lobster/evergreen/test/cloud_automation_master_osx_OSXTestGroup30_patch_3f3b52b4a01c930019cd785796236717d9add0e9_606c8f38d6d80a4931eeb038_21_04_06_16_41_29/0/606ca5f18193f511fcbc8fb4#bookmarks=10959

http://localhost:3000/lobster/evergreen/test/spruce_ubuntu1604_e2e_test_patch_e781f24c8602347e3ecbc346fbc5ff1eda838d52_6065d1a72fbabe558e5fa9d7_21_04_01_14_01_12/0/Display_success_toast_after_submitting_a_valid_form_with_regex_selectors_inputs_and_request_succeeds.Version_Subscription_Modal_Regex_selector_inputs_Display_success_toast_after_submitting_a_valid_form_with_regex_selectors_inputs_and_request_succeeds

these code changes also adjust the link generation for TEST RAW/HTML log btn href to evergreen. the video shows the working feature update: 


https://user-images.githubusercontent.com/10734386/114047121-6e988c80-9857-11eb-93d1-62852f2d9477.mov

