### PR TITLE
EVG-14222: Repair initial load scroll state & adjust visual information

### DIFF
--- a/src/components/LogView/FullLogLine.js
+++ b/src/components/LogView/FullLogLine.js
@@ -6,7 +6,6 @@ import { faLink, faArrowCircleLeft } from "@fortawesome/free-solid-svg-icons";
 import LogLineText from "./LogLineText";
 import { connect } from "react-redux";
 import LineNumber from "./LineNumber";
-import * as selectors from "../../selectors";
 import * as actions from "../../actions";
 import LogOptions from "./LogOptions";
 import queryString from "../../thirdparty/query-string";

--- a/src/components/LogView/index.js
+++ b/src/components/LogView/index.js
@@ -69,7 +69,7 @@ class LogView extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      hasScrolledToShareLine: props.bookmarks.length === 0,
+      hasScrolledToShareLine: false,
       selectStartIndex: null,
       selectEndIndex: null,
       clicks: [],
@@ -374,10 +374,6 @@ class LogView extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const currBookmarksSet = new Set(
-      this.props.bookmarks.map(({ lineNumber }) => lineNumber)
-    );
-    const lastLineNo = this.state.lines.length - 1;
     // handle initial bookmark scroll
     if (
       this.props.scrollLine !== null &&

--- a/src/components/LogView/style.css
+++ b/src/components/LogView/style.css
@@ -1,5 +1,5 @@
-.bookmark-line { background-color: #ffffb3; }
-.share-line { background-color: #FFD9B3 !important;}
+.bookmark-line { background-color: #ffffb3 !important; }
+.share-line { background-color: #FFD9B3;}
 .highlighted { background-color: #fff0f2; }
 .filtered { background-color: #ffdde3; }
 .no-match { background-color: #e8e7d9; }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-14222
bookmarked shareLines will be highlighted as a bookmarked line (yellow) instead of orange since we already indicate the shareLine with a left arrow icon. this makes it easier for the user to identify sharelines apart from bookmarked sharelines apart from shareLines that are bookmarked