### PR TITLE
EVG-14866: Link to Spruce Job Logs page for tests

### DIFF
--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -188,7 +188,6 @@ function showDetailButtons(
     );
   } else if (id.type === "evergreen-test") {
     const { logs, group_id, execution, task_id } = testMetadata || {};
-
     const { url_html_display, url_raw_display } = logs || {};
     if (Number.isFinite(execution) && group_id && task_id) {
       buttons.push(

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -192,7 +192,7 @@ function showDetailButtons(
     if (Number.isFinite(execution) && task_id) {
       buttons.push(
         <Col key={0} lg={1}>
-          <Button style={col0Style} href={`${SPRUCE_BASE}/job-logs/${task_id}/${execution}${groupId ? `/${group_id}` : ""}`}>
+          <Button style={col0Style} href={`${SPRUCE_BASE}/job-logs/${task_id}/${execution}${group_id ? `/${group_id}` : ""}`}>
             Job Logs
           </Button>
         </Col>

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -3,7 +3,7 @@
 import React from "react";
 import type { Node as ReactNode } from "react";
 import { getTestMetadata, type TestMetadata } from "../../util";
-import { EVERGREEN_BASE, LOGKEEPER_BASE } from "../../config";
+import { EVERGREEN_BASE, LOGKEEPER_BASE, SPRUCE_BASE } from "../../config";
 import "./style.css";
 import {
   Button,
@@ -187,8 +187,18 @@ function showDetailButtons(
       ]
     );
   } else if (id.type === "evergreen-test") {
-    const { logs } = testMetadata || {};
+    const { logs, group_id, execution, task_id } = testMetadata || {};
+
     const { url_html_display, url_raw_display } = logs || {};
+    if (Number.isFinite(execution) && group_id && task_id) {
+      buttons.push(
+        <Col key={0} lg={1}>
+          <Button style={col0Style} href={`${SPRUCE_BASE}/job-logs/${task_id}/${execution}/${group_id}`}>
+            Job Logs
+          </Button>
+        </Col>
+      )
+    }
     if (url_html_display && url_raw_display) {
       buttons.push(
         ...[

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -189,10 +189,10 @@ function showDetailButtons(
   } else if (id.type === "evergreen-test") {
     const { logs, group_id, execution, task_id } = testMetadata || {};
     const { url_html_display, url_raw_display } = logs || {};
-    if (Number.isFinite(execution) && group_id && task_id) {
+    if (Number.isFinite(execution) && task_id) {
       buttons.push(
         <Col key={0} lg={1}>
-          <Button style={col0Style} href={`${SPRUCE_BASE}/job-logs/${task_id}/${execution}/${group_id}`}>
+          <Button style={col0Style} href={`${SPRUCE_BASE}/job-logs/${task_id}/${execution}${groupId ? `/${group_id}` : ""}`}>
             Job Logs
           </Button>
         </Col>

--- a/src/config.js
+++ b/src/config.js
@@ -5,3 +5,6 @@ export const LOGKEEPER_BASE: string =
   process.env.REACT_APP_LOGKEEPER_BASE || 'https://logkeeper.mongodb.org';
 export const EVERGREEN_BASE: string =
   process.env.REACT_APP_EVERGREEN_BASE || 'https://evergreen.mongodb.com';
+ export const SPRUCE_BASE: string =
+  process.env.REACT_APP_SPRUCE_BASE || 'https://spruce.mongodb.com';
+


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-14866
the Job Logs page (https://github.com/evergreen-ci/spruce/pull/809) should be deployed before these code changes
you can see the button after running `npm run start` and navigating to: http://localhost:3000/lobster/evergreen/test/mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_required_noPassthrough_0_enterprise_rhel_80_64_bit_dynamic_required_patch_a93e160436297f2a853b59e40eeb8c186b1879cf_60c383ba3066150a721e3504_21_06_11_15_40_07/0/60c3909e3fc0600c69fd458b#bookmarks=0%2C396&l=1
![Screen Shot 2021-07-09 at 1 48 33 PM](https://user-images.githubusercontent.com/10734386/125117671-90a2e480-e0bc-11eb-8212-45e658e1573d.png)
