### PR TITLE
EVG-15000: Render complete test logs in spruce

### DIFF
--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -40,7 +40,7 @@ export function testLogCompleteURL(
   execution: string,
   html: boolean,
 ): string {
-  return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}?group_id=${groupId}${html ? "" : "&text=true"}`;
+  return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}?${groupId ? `group_id=${groupId}&`: ""}${html ? "" : "text=true"}`;
 }
 
 export function testLogByNameURL(

--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -36,8 +36,8 @@ export function testLogRawURL(
 
 export function testLogCompleteURL(
   taskId: string,
-  groupId: string,
   execution: string,
+  groupId: string,
   html: boolean,
 ): string {
   return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}?${groupId ? `group_id=${groupId}&`: ""}${html ? "" : "text=true"}`;

--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -34,6 +34,14 @@ export function testLogRawURL(
   return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}/${id}?text=true`;
 }
 
+export function testLogCompleteRawURL(
+  taskId: string,
+  groupId: string,
+  execution: string
+): string {
+  return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}?group_id=${groupId}&text=true`;
+}
+
 export function testLogByNameURL(
   task: string,
   execution: number,

--- a/src/api/evergreen.js
+++ b/src/api/evergreen.js
@@ -34,12 +34,13 @@ export function testLogRawURL(
   return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}/${id}?text=true`;
 }
 
-export function testLogCompleteRawURL(
+export function testLogCompleteURL(
   taskId: string,
   groupId: string,
-  execution: string
+  execution: string,
+  html: boolean,
 ): string {
-  return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}?group_id=${groupId}&text=true`;
+  return `${EVERGREEN_BASE}/test_log/${taskId}/${execution}?group_id=${groupId}${html ? "" : "&text=true"}`;
 }
 
 export function testLogByNameURL(
@@ -71,7 +72,9 @@ export function taskURL(taskID: string, execution: ?number): string {
 export async function fetchEvergreen(log: EvergreenLog): Promise<Response> {
   const init = { method: "GET", credentials: "include" };
   let req = "";
-  if (log.type === "evergreen-task") {
+  if (log.type === "evergreen-test-complete") {
+    req = new Request(testLogCompleteURL(log.taskId, log.execution, log.groupId), init);
+  } else if (log.type === "evergreen-task") {
     req = new Request(taskLogRawURL(log.id, log.execution, log.log), init);
   } else if (log.type === "evergreen-test") {
     const { execution, testId, taskId } = log;

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -51,6 +51,11 @@ const Main = () => (
         path="/lobster/evergreen/test/:taskId/:execution/:testId"
         render={evergreenLogviewer}
       />
+      <Route
+        exact
+        path="/lobster/evergreen/complete-test/:taskId/:execution/:groupId"
+        render={evergreenLogviewer}
+      />
       <Route path="/lobster/logdrop" render={logviewer} />
       <Route path="/lobster" render={logdrop} />
       <Route path="*" render={notfound} />

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -53,7 +53,7 @@ const Main = () => (
       />
       <Route
         exact
-        path="/lobster/evergreen/complete-test/:taskId/:execution/:groupId"
+        path="/lobster/evergreen/complete-test/:taskId/:execution/:groupId?"
         render={evergreenLogviewer}
       />
       <Route path="/lobster/logdrop" render={logviewer} />

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -186,6 +186,29 @@ function showDetailButtons(
         </Col>,
       ]
     );
+  } else if (id.type === "evergreen-test-complete") {
+    console.log("evrgreen-test-complete collapse menu", id)
+    const { taskId, execution, groupId } = id
+    buttons.push(
+      ...[
+        <Col key={1} lg={1}>
+          <Button
+            style={col0Style}
+            href={api.testLogCompleteURL(taskId, execution, groupId)}
+          >
+            Raw
+          </Button>
+        </Col>,
+        <Col key={2} lg={1}>
+          <Button
+            style={col1Style}
+            href={api.testLogCompleteURL(taskId, execution, groupId, true)}
+          >
+            HTML
+          </Button>
+        </Col>,
+      ]
+    );
   } else if (id.type === "evergreen-test") {
     const { logs } = testMetadata || {};
     const { url_html_display, url_raw_display } = logs || {};

--- a/src/components/Fetch/EvergreenLogViewer.js
+++ b/src/components/Fetch/EvergreenLogViewer.js
@@ -24,10 +24,10 @@ function makeEvergreenLogID(params: {
     };
   }
 
-  if (execution && taskId && groupId && !testId) {
+  if (execution && taskId && !testId) {
     return {
       type: "evergreen-test-complete",
-      groupId,
+      groupId: groupId || "",
       execution: executionAsNumber,
       taskId,
     };

--- a/src/components/Fetch/EvergreenLogViewer.js
+++ b/src/components/Fetch/EvergreenLogViewer.js
@@ -10,8 +10,9 @@ function makeEvergreenLogID(params: {
   execution: ?string,
   testId: ?string,
   taskId: ?string,
+  groupId: ?string
 }): ?LogIdentity {
-  const { logType, execution, testId, taskId } = params;
+  const { logType, execution, testId, taskId, groupId } = params;
   const executionAsNumber = parseInt(execution, 10) || 0;
 
   if (logType) {
@@ -20,6 +21,15 @@ function makeEvergreenLogID(params: {
       id: taskId || "",
       execution: executionAsNumber,
       log: stringToEvergreenTaskLogType(logType),
+    };
+  }
+
+  if (execution && taskId && groupId && !testId) {
+    return {
+      type: "evergreen-test-complete",
+      groupId,
+      execution: executionAsNumber,
+      taskId,
     };
   }
 

--- a/src/models.js
+++ b/src/models.js
@@ -217,6 +217,13 @@ export type EvergreenTestLog = $ReadOnly<{
   testId: string,
 }>;
 
+export type EvergreenTestLogComplete = $ReadOnly<{
+  type: "evergreen-test-complete",
+  taskId: string,
+  execution: number,
+  groupId: string,
+}>;
+
 export type EvergreenTestByNameLog = $ReadOnly<{
   type: "evergreen-test-by-name",
   task: string,
@@ -227,7 +234,8 @@ export type EvergreenTestByNameLog = $ReadOnly<{
 export type EvergreenLog =
   | EvergreenTaskLog
   | EvergreenTestLog
-  | EvergreenTestByNameLog;
+  | EvergreenTestByNameLog
+  | EvergreenTestLogComplete;
 
 export type LobsterLog = $ReadOnly<{
   type: "lobster",

--- a/src/sagas/logfetchers.js
+++ b/src/sagas/logfetchers.js
@@ -104,6 +104,7 @@ export function* evergreenLoadData(identity: EvergreenLog): Saga<void> {
 export default function* (action: actions.LoadLog): Saga<void> {
   const { identity } = action.payload;
   switch (identity.type) {
+    case "evergreen-test-complete":
     case "evergreen-test":
     case "evergreen-test-by-name":
     case "evergreen-task":


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-15000

render "complete test logs" linked from the spuce job logs page (https://github.com/evergreen-ci/spruce/pull/809)
you can see the code changes run by starting `npm run start` and navigating to http://localhost:3000/lobster/evergreen/complete-test/mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_required_noPassthroughWithMongod_1_enterprise_rhel_80_64_bit_dynamic_required_patch_a93e160436297f2a853b59e40eeb8c186b1879cf_60c383ba3066150a721e3504_21_06_11_15_40_07/0/0#bookmarks=0%2C798&l=1&shareLine=9

we are also able to render logs by omitting the groupId. here is the same taskId and exec combo with the groupId omitted (last value in pathname):
http://localhost:3000/lobster/evergreen/complete-test/mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_required_noPassthroughWithMongod_1_enterprise_rhel_80_64_bit_dynamic_required_patch_a93e160436297f2a853b59e40eeb8c186b1879cf_60c383ba3066150a721e3504_21_06_11_15_40_07/0#bookmarks=0%2C81980&l=1



https://user-images.githubusercontent.com/80338999/125683998-d91b1a2c-dd51-4870-8412-088007395d27.mov

