### PR TITLE
EVG-15003: Change classname to prevent Adblock detection

### DIFF
--- a/src/components/LogView/FullLogLine.js
+++ b/src/components/LogView/FullLogLine.js
@@ -78,7 +78,7 @@ class FullLogLine extends React.Component<Props, State> {
       className += " bookmark-line";
     }
     if (this.props.isShareLine) {
-      className += " share-line";
+      className += " tan-background";
     }
     if (!this.props.wrap) {
       className += " no-wrap";

--- a/src/components/LogView/style.css
+++ b/src/components/LogView/style.css
@@ -1,5 +1,5 @@
 .bookmark-line { background-color: #ffffb3 !important; }
-.share-line { background-color: #FFD9B3;}
+.tan-background { background-color: #FFD9B3;}
 .highlighted { background-color: #fff0f2; }
 .filtered { background-color: #ffdde3; }
 .no-match { background-color: #e8e7d9; }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-15003
Some browser adblocking tools hide elements with the classname "share-line". These code changes replace "share-line" to "tan-background" to prevent adblock detection 