### PR TITLE
EVG-16537 Default to empty url for prod builds so links use relative domain

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ export const isProd: boolean = process.env.NODE_ENV === 'production';
 export const LOGKEEPER_BASE: string =
   process.env.REACT_APP_LOGKEEPER_BASE || 'https://logkeeper.mongodb.org';
 export const EVERGREEN_BASE: string =
-  process.env.REACT_APP_EVERGREEN_BASE || 'https://evergreen.mongodb.com';
+  process.env.REACT_APP_EVERGREEN_BASE || '';
  export const SPRUCE_BASE: string =
   process.env.REACT_APP_SPRUCE_BASE || 'https://spruce.mongodb.com';
 


### PR DESCRIPTION
Lobster should use the relative domain from where ever it is hosted