### PR TITLE
EVG-17425: Set the Logkeeper Base URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "yargs": "^12.0.1"
   },
   "scripts": {
-    "start": "export REACT_APP_LOGKEEPER_BASE=https://logkeeper.mongodb.org; export REACT_APP_EVERGREEN_BASE=https://evergreen.mongodb.com; react-scripts start",
+    "start": "export REACT_APP_LOGKEEPER_BASE=https://logkeeper.mongodb.org; export REACT_APP_EVERGREEN_BASE=https://evergreen.mongodb.com; REACT_APP_NEW_LOGKEEPER_BASE=https://logkeeper2.build.10gen.cc; react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "test:ci": "react-scripts test --testResultsProcessor=./reporter --env=jsdom",

--- a/src/api/logkeeper.js
+++ b/src/api/logkeeper.js
@@ -1,24 +1,30 @@
 // @flow strict
 
-import { LOGKEEPER_BASE } from "../config";
+import { LOGKEEPER_BASE, NEW_LOGKEEPER_BASE } from "../config";
 
-function generateLogkeeperUrl(buildParam: string, testParam: ?string): string {
+export async function getLogkeeperBaseURL(buildParam: string, testParam: ?string): string {
+  const res = await window.fetch(generateLogkeeperUrl(NEW_LOGKEEPER_BASE, buildParam, testParam));
+  return res.ok ? NEW_LOGKEEPER_BASE : LOGKEEPER_BASE;
+} 
+
+function generateLogkeeperUrl(base: string, buildParam: string, testParam: ?string): string {
   if (!buildParam) {
     return "";
   }
   if (!testParam) {
-    return LOGKEEPER_BASE + "/build/" + buildParam + "/all?raw=1";
+    return base + "/build/" + buildParam + "/all?raw=1";
   }
   return (
-    LOGKEEPER_BASE + "/build/" + buildParam + "/test/" + testParam + "?raw=1"
+    base + "/build/" + buildParam + "/test/" + testParam + "?raw=1"
   );
 }
 
-export function fetchLogkeeper(
+export async function fetchLogkeeper(
   build: string,
   test: ?string
 ): Promise<Response> {
-  const req = new Request(generateLogkeeperUrl(build, test), { method: "GET" });
+  const baseURL = await getLogkeeperBaseURL(build, test) 
+  const req = new Request(generateLogkeeperUrl(baseURL, build, test), { method: "GET" });
   return window.fetch(req);
 }
 
@@ -33,5 +39,5 @@ export function fetchLobster(server: string, url: string): Promise<Response> {
     }),
   };
   const req = new Request(`http://${server}`, init);
-  return window.fetch(req);
+  return window.fetch(req);  
 }

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import type { Node as ReactNode } from "react";
-import { EVERGREEN_BASE, LOGKEEPER_BASE, SPRUCE_BASE } from "../../config";
+import {  SPRUCE_BASE } from "../../config";
 import "./style.css";
 import {
   Button,
@@ -30,6 +30,7 @@ import type {
   Bookmark,
   Line,
 } from "../../models";
+import { getLogkeeperBaseURL } from "../../api";
 
 type Props = {
   settings: Settings,
@@ -97,6 +98,7 @@ function showLogBox(
 function showDetailButtons(
   id: ?LogIdentity,
   clearCache: ?() => void,
+  logkeeperBaseURL
 ): ?ReactNode {
   if (!id) {
     return null;
@@ -110,17 +112,17 @@ function showDetailButtons(
       const { build } = id;
       buttons.push(
           <Col key={0} lg={1}>
-            <Button style={col0Style} href={`${LOGKEEPER_BASE}/build/${build}`}>
+            <Button style={col0Style} href={`${logkeeperBaseURL}/build/${build}`}>
               Job Logs
             </Button>
           </Col>,
           <Col key={1} lg={1}>
-            <Button style={col1Style} href={`${LOGKEEPER_BASE}/build/${build}/all?raw=1`}>
+            <Button style={col1Style} href={`${logkeeperBaseURL}/build/${build}/all?raw=1`}>
               Raw
             </Button>
           </Col>,
           <Col key={2} lg={1}>
-            <Button style={col2Style} href={`${LOGKEEPER_BASE}/build/${build}/all?html=1`}>
+            <Button style={col2Style} href={`${logkeeperBaseURL}/build/${build}/all?html=1`}>
               HTML
             </Button>
           </Col>,
@@ -129,14 +131,14 @@ function showDetailButtons(
       const { build, test } = id;
       buttons.push(
           <Col key={0} lg={1}>
-            <Button style={col0Style} href={`${LOGKEEPER_BASE}/build/${build}`}>
+            <Button style={col0Style} href={`${logkeeperBaseURL}/build/${build}`}>
               Job Logs
             </Button>
           </Col>,
           <Col key={1} lg={1}>
             <Button
               style={col1Style}
-              href={`${LOGKEEPER_BASE}/build/${build}/test/${test}?raw=1`}
+              href={`${logkeeperBaseURL}/build/${build}/test/${test}?raw=1`}
             >
               Raw
             </Button>
@@ -144,7 +146,7 @@ function showDetailButtons(
           <Col key={2} lg={1}>
             <Button
               style={col2Style}
-              href={`${LOGKEEPER_BASE}/build/${build}/test/${test}?html=1`}
+              href={`${logkeeperBaseURL}/build/${build}/test/${test}?html=1`}
             >
               HTML
             </Button>
@@ -242,6 +244,15 @@ export class CollapseMenu extends React.PureComponent<Props> {
   endRangeInput: ?HTMLInputElement;
   constructor(props) {
     super(props);
+    this.state = {}
+  }
+  async componentDidUpdate() {
+    const { logIdentity } = this.props;
+    if(logIdentity.type === "logkeeper" && !this.state.logkeeperBaseURL) {
+      getLogkeeperBaseURL(logIdentity.build, logIdentity.test).then(logkeeperBaseURL => {
+        this.setState({ ...this.state, logkeeperBaseURL })
+      })
+    }
   }
   setURLRef = (ref: ?HTMLInputElement) => {
     this.urlInput = ref;
@@ -453,6 +464,7 @@ export class CollapseMenu extends React.PureComponent<Props> {
               {showDetailButtons(
                 this.props.logIdentity,
                 this.props.wipeCache,
+                this.state.logkeeperBaseURL
               )}
             </FormGroup>
           </Form>

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,8 @@
 export const isProd: boolean = process.env.NODE_ENV === 'production';
 export const LOGKEEPER_BASE: string =
   process.env.REACT_APP_LOGKEEPER_BASE || 'https://logkeeper.mongodb.org';
+export const NEW_LOGKEEPER_BASE: string =
+  process.env.REACT_APP_NEW_LOGKEEPER_BASE || 'https://logkeeper2.build.10gen.cc'; 
 export const EVERGREEN_BASE: string =
   process.env.REACT_APP_EVERGREEN_BASE || '';
  export const SPRUCE_BASE: string =


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-17425

I set the logkeeper base URL based on a request to the new logkeeper service. I chose the new logkeeper service to do the check because I'm under the impression the new service is less likely to contain the result the user is looking for during the coming week so the check could result in less data transfer.
It's pretty confusing to set the logkeeperBaseURL as part of the global application state so I opted to run the function in two places where the result is needed. 
You can test these code changes by pulling them, installing the node_modules and viewing logkeeper logs that exist on the new and old services. Examine then network requests and click the buttons and click the "RAW" and "HTML" log buttons in the "Show Details" menu. 
<img width="201" alt="Screen Shot 2022-08-05 at 3 01 19 PM" src="https://user-images.githubusercontent.com/10734386/183143957-c8915cb3-68b0-468c-9c9b-05187f8e71bb.png">
These two links render logs from each logkeeper service: 
http://localhost:3000/lobster/build/321662d0fb6c60eec7166c1591dca54e/test/62ed1b1fbe07c435a39a1bd6#bookmarks=0%2C425
http://localhost:3000/lobster/build/8be6cac51d7e8bdf7b5c120c91a1bf6e/test/62ed1707c5e2faef36be7bc7#bookmarks=0%2C2613