### PR TITLE
EVG-17438 use build route

### DIFF
--- a/src/api/logkeeper.js
+++ b/src/api/logkeeper.js
@@ -2,8 +2,8 @@
 
 import { LOGKEEPER_BASE, NEW_LOGKEEPER_BASE } from "../config";
 
-export async function getLogkeeperBaseURL(buildParam: string, testParam: ?string): string {
-  const res = await window.fetch(generateLogkeeperUrl(NEW_LOGKEEPER_BASE, buildParam, testParam));
+export async function getLogkeeperBaseURL(buildParam: string): string {
+  const res = await window.fetch(NEW_LOGKEEPER_BASE + "/build/"+ buildParam);
   return res.ok ? NEW_LOGKEEPER_BASE : LOGKEEPER_BASE;
 } 
 
@@ -23,7 +23,7 @@ export async function fetchLogkeeper(
   build: string,
   test: ?string
 ): Promise<Response> {
-  const baseURL = await getLogkeeperBaseURL(build, test) 
+  const baseURL = await getLogkeeperBaseURL(build)
   const req = new Request(generateLogkeeperUrl(baseURL, build, test), { method: "GET" });
   return window.fetch(req);
 }

--- a/src/components/Fetch/CollapseMenu.js
+++ b/src/components/Fetch/CollapseMenu.js
@@ -249,7 +249,7 @@ export class CollapseMenu extends React.PureComponent<Props> {
   async componentDidUpdate() {
     const { logIdentity } = this.props;
     if(logIdentity.type === "logkeeper" && !this.state.logkeeperBaseURL) {
-      getLogkeeperBaseURL(logIdentity.build, logIdentity.test).then(logkeeperBaseURL => {
+      getLogkeeperBaseURL(logIdentity.build).then(logkeeperBaseURL => {
         this.setState({ ...this.state, logkeeperBaseURL })
       })
     }


### PR DESCRIPTION
[EVG-17438](https://jira.mongodb.org/browse/EVG-17438)

Logkeeper already has a route that just returns an HTML page with information about a build (like [this one](https://logkeeper2.staging.build.10gen.cc/build/0a141b341b1a7446e5123836940b8e88)). Since we don't need to fetch logs for it it's likely to be much faster. 
It didn't seem worthwhile to implement a whole separate route on Logkeeper that just returns something like `{exists: true}`, though I could if we think it makes sense.